### PR TITLE
Attach platform tarballs as release assets

### DIFF
--- a/ci/scripts/release
+++ b/ci/scripts/release
@@ -75,12 +75,12 @@ if [[ -n "$PRERELEASE" ]] ; then
   cp    git/.git/ref            "${RELEASE_ROOT}/commit"
   for dir in build-linux-amd64 build-linux-arm64 build-darwin-amd64 build-darwin-arm64; do
     for f in "${dir}"/*.tar.gz; do
-      [[ -f "$f" ]] && tar -zxvf "$f" -C "${RELEASE_ROOT}/artifacts"
+      [[ -f "$f" ]] && cp "$f" "${RELEASE_ROOT}/artifacts/"
     done
   done
 else
   for f in ${REPO_ROOT}/builds/${APP_NAME}-*.tar.gz; do
-    [[ -f "$f" ]] && tar -zxvf "$f" -C "${RELEASE_ROOT}/artifacts"
+    [[ -f "$f" ]] && cp "$f" "${RELEASE_ROOT}/artifacts/"
   done
 fi
 


### PR DESCRIPTION
## Problem

`ship-prerelease` fails at the final upload:

```
uploading /tmp/build/put/gh/artifacts/darwin-amd64-2.0.1-rc.1
error running command: the asset to upload can't be a directory
```

Everything upstream succeeds — the build, re-link, checksums, and
release notes all complete. Only the GitHub asset upload fails.

## Cause

Each per-platform tarball contains a top-level directory, e.g.
`linux-amd64-<version>/` holding `scheduler`, `tzlist`, and their
`.sha1`/`.sha256` files.

`ci/scripts/release` untarred these into `gh/artifacts/`, leaving four
directories there. The pipeline's `put` uses `globs: [gh/artifacts/*]`,
and the `github-release` resource refuses to upload a directory.

## Fix

Copy the tarballs into `gh/artifacts/` instead of extracting them, so
each platform ships as a single release asset:

```
ocf-scheduler-linux-amd64-<version>.tar.gz
ocf-scheduler-linux-arm64-<version>.tar.gz
ocf-scheduler-darwin-amd64-<version>.tar.gz
ocf-scheduler-darwin-arm64-<version>.tar.gz
```

Both branches of the conditional are fixed — the prerelease path and
the release path — so this also clears the same latent failure in
`ship-release`, which had not yet been exercised with the new re-link
flow.

## Notes

- No repipe required; `ci/pipeline/` is unchanged. The script is read
  from the `git-ci` resource, so this takes effect once merged.
- Release assets are now per-platform archives rather than the single
  bare binary used through v2.0.0. That naming came from the upstream
  template, which compiled and shipped in one job and only ever
  produced one platform.
- The empty `v2.0.1-rc.1` prerelease and tag created by the failed run
  have been deleted, so a retry starts clean.