### PR TITLE
Pin relink toolchain to the one that built it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,11 @@ relink:
 	@WORKDIR_BASE=$$(mktemp -d) && \
 	echo "Extracting workdir archive from $(WORKDIR_ARCHIVE)..." && \
 	tar -xzf $(WORKDIR_ARCHIVE) -C $$WORKDIR_BASE && \
+	GOTOOLCHAIN=$$(grep -a -m1 -o 'go object [a-z0-9]* [a-z0-9]* go1[0-9.]*' \
+		$$(find $$WORKDIR_BASE -name '*.a' | head -1) | awk '{print $$5}') && \
+	{ test -n "$$GOTOOLCHAIN" || { echo "Cannot determine Go toolchain from workdir archives" >&2; exit 1; }; } && \
+	export GOTOOLCHAIN && \
+	echo "Re-linking with toolchain $$GOTOOLCHAIN" && \
 	rm -rf $(RELEASE_ROOT) && mkdir -p $(RELEASE_ROOT) && \
 	for target in $(TARGETS); do \
 		os=$${target%%/*} && \


### PR DESCRIPTION
## Problem

`ship-release/5` failed on every one of the eight link invocations
(4 platforms x `scheduler`/`tzlist`):

```
archives/5.a(_go_.o): linked object header mismatch:
have "go object linux amd64 go1.26.0 ... dwarf5,greenteagc,randomizedheapbase64"
want "go object linux amd64 go1.22.4 ... coverageredesign,allocheaders,exectracer2"
/usr/local/go/pkg/tool/linux_amd64/link: too many errors
make: *** [Makefile:222: relink] Error 1
```

The archives were compiled by go1.26.0; the linker running was go1.22.4.

## Cause

`build` and `ship-release` use the *same* image
(`genesis-community/concourse-go`, Go 1.22.4). The difference is the
working directory when the `go` command runs:

- `build` runs `go build -work` from the repo root. `go.mod` declares
  `go 1.26.0`, so `GOTOOLCHAIN=auto` downloads and switches to
  go1.26.0. The archives come out go1.26.0.
- `relink` runs `go tool link` inside a temp dir extracted from the
  workdir archive. There is no `go.mod` there, so no switch happens
  and the image's built-in go1.22.4 linker runs.

Same image, same `go` on PATH, different toolchain resolution purely
because of the `cd`.

## Fix

Every Go object header records the toolchain that produced it, so the
archives already carry the answer:

```
go object linux amd64 go1.26.0 GOAMD64=v1 X:regabiwrappers,...
```

Read it back from the first archive and export `GOTOOLCHAIN` before
linking. Deriving it from the artifact rather than from `go.mod` keeps
the two halves in step even if `go.mod` moves between a build and the
release that consumes its workdir.

## Verification

- `make -n relink` — recipe expands correctly, no macro-expansion
  surprises (`$$5` -> `$5`, quoting intact)
- extraction tested against a real 59-archive workdir laid out the way
  the tarball stores it -> resolved the correct toolchain
- guard tested against an archive-less workdir -> error message, exit 1

Not yet exercised in CI. The release container will download the
pinned toolchain (~100 MB); `build` already does exactly this under
`GOTOOLCHAIN=auto`, so it is proven to work in that environment.