### PR TITLE
Pass RELEASE_ROOT explicitly to relink

### DIFF
--- a/ci/scripts/release
+++ b/ci/scripts/release
@@ -60,7 +60,11 @@ echo "Environment OK"
 
 if [[ -z "${PRERELEASE}" ]] ; then
   header "Re-linking binaries with release version..."
-  (cd ${REPO_ROOT} && make relink VERSION=${VERSION} APP_NAME=${APP_NAME} \
+  # RELEASE_ROOT is set to the Github staging dir for this task, but the
+  # Makefile uses it as the build output dir.  Pass it explicitly so make
+  # does not inherit it and write the tarballs somewhere the glob below
+  # will not find them.
+  (cd ${REPO_ROOT} && make relink RELEASE_ROOT=builds VERSION=${VERSION} APP_NAME=${APP_NAME} \
     WORKDIR_ARCHIVE="$(pwd)/../build-workdir/${APP_NAME}-workdir-"*.tar.gz)
 fi
 


### PR DESCRIPTION
## Problem

`ship-release/6` re-linked all eight binaries successfully, pushed
`main`, and created the `v2.0.1` tag -- then failed on the upload:

```
creating release v2.0.1
error running command: could not find file that matches glob 'gh/artifacts/*'
```

It left a partial release: `main` advanced, tag `v2.0.1` created,
GitHub release created but with zero assets, version never bumped.

## Cause

`RELEASE_ROOT` means two different things:

- `ci/pipeline/jobs/ship-release.yml:21` sets `RELEASE_ROOT: gh`, the
  staging dir the github-release resource uploads from
- `Makefile:9` declares `RELEASE_ROOT ?= releases`, the build output dir

`?=` lets the environment win, so `make relink` -- run via
`(cd ${REPO_ROOT} && make relink ...)` -- wrote the re-linked tarballs
into `git/gh/`. The assembly loop globs `${REPO_ROOT}/builds/`, which
nothing populates, so `gh/artifacts/` stayed empty.

Two unrelated directories named `gh` are in play: `./gh` (the task
output) and `git/gh` (where make put the tarballs).

## Fix

Pass `RELEASE_ROOT` on the make command line. A command-line assignment
overrides both the environment and `?=`, so the tarballs land in
`git/builds/` where the glob expects them -- matching how
`ci/scripts/build` already directs its output.

## Verification

Reproduced and confirmed with `make -n`:

```
$ RELEASE_ROOT=gh make -n relink ...              # before
        rm -rf gh && mkdir -p gh && \
$ RELEASE_ROOT=gh make -n relink ... RELEASE_ROOT=builds   # after
        rm -rf builds && mkdir -p builds && \
```

`bash -n ci/scripts/release` passes.

## Notes

- Pre-existing, not a regression from the earlier `cp` change. The old
  code globbed the same empty path with `tar -zxvf`; an unmatched glob
  leaves `$f` as the literal pattern, `[[ -f "$f" ]]` is false, and it
  silently extracted nothing.
- Touches only `ci/`, which the `git-ci` resource serves unconstrained,
  so no new build/test/prepare cycle is needed to pick this up.
- The empty `v2.0.1` release and tag must be deleted before retrying,
  or `put: git-main` will try to re-push an existing tag.
- Separately, the release body came back empty (`bodyLen: 0`). The notes
  header matched so the script did not bail, but there is no content
  under it. Not addressed here.