### PR TITLE
Name the failing job in Slack alerts

### DIFF
--- a/ci/pipeline/jobs/build.yml
+++ b/ci/pipeline/jobs/build.yml
@@ -43,4 +43,4 @@ jobs:
     params:
       username: (( grab meta.slack.username ))
       icon_url: (( grab meta.slack.icon ))
-      text:    '(( concat meta.slack.fail_url " " meta.pipeline ": test job failed" ))'
+      text:    '(( concat meta.slack.fail_url " " meta.pipeline ": build job failed" ))'

--- a/ci/pipeline/jobs/ship-release.yml
+++ b/ci/pipeline/jobs/ship-release.yml
@@ -48,4 +48,4 @@ jobs:
       params:
         username: (( grab meta.slack.username ))
         icon_url: (( grab meta.slack.icon ))
-        text:    '(( concat meta.slack.fail_url " " meta.pipeline ": prepare job failed" ))'
+        text:    '(( concat meta.slack.fail_url " " meta.pipeline ": ship release job failed" ))'

--- a/ci/pipeline/jobs/test-pr.yml
+++ b/ci/pipeline/jobs/test-pr.yml
@@ -60,5 +60,5 @@ jobs:
       params:
         username: (( grab meta.slack.username ))
         icon_url: (( grab meta.slack.icon ))
-        text:    '(( concat meta.slack.fail_url " " meta.pipeline ": test job failed" ))'
+        text:    '(( concat meta.slack.fail_url " " meta.pipeline ": test pull request job failed" ))'
 


### PR DESCRIPTION
## Problem

Three `on_failure` handlers named a job other than the one they belong
to, so Slack alerts pointed at the wrong place:

| job | announced |
|-----|-----------|
| `build` | "test job failed" |
| `ship-release` | "prepare job failed" |
| `test-pr` | "test job failed" |

The first two are copy-paste errors. This was not cosmetic -- during
the recent outage, builds 19 through 42 failed while uploading
artifacts but told Slack the *test suite* had broken, which points a
responder at entirely the wrong subsystem.

`ship-release/7` failed earlier today and reported itself as `prepare`.

The `test-pr` case is ambiguous rather than wrong: it is a test job,
but so is `test`, and the alert could not distinguish the two.

## Fix

Each message now names its own job:

```
build           -> build job failed
prepare         -> prepare job failed
ship-prerelease -> ship prerelease job failed
ship-release    -> ship release job failed
test            -> test job failed
test-pr         -> test pull request job failed
version-major   -> update version major job failed
version-minor   -> update version minor job failed
version-patch   -> update version patch job failed
```

## Verification

`./ci/repipe -vv` -> `looks good`

## Note

Unlike the previous two fixes, this touches `ci/pipeline/`, so it needs
a **repipe** after merging -- merging alone will not change the running
pipeline.