### PR TITLE
Document timezone handling in v2.0.1 notes

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -66,6 +66,31 @@ Cyclic ranges also work in step expressions
 |:---------|:-------: |-----------|
 |20-2/2    |hours     | every 2 hours from 8 pm(20) to 2 am|
 
+## Timezones
+
+A schedule may declare its own timezone by prefixing the cron expression with `TZ=` or
+`CRON_TZ=`:
+
+```
+CRON_TZ=America/New_York 0 30 9 * * MON-FRI
+TZ="Europe/Berlin" 0 0 3 * * *
+```
+
+The expression is evaluated in the declared zone, and the resulting fire time is then
+converted to the scheduler's own timezone. An expression with no prefix is evaluated
+directly in the scheduler's timezone.
+
+The prefix itself is not new, but two things around it are:
+
+* Matching single or double quotes around the zone name are now accepted —
+  `TZ="Europe/Berlin"` and `TZ='UTC'` both work. Previously the quotes were passed through
+  to the zone lookup and the schedule was rejected.
+* An unknown zone is rejected when the schedule is created rather than failing later.
+
+The zones the scheduler recognises can now be listed through the new authenticated
+`GET /scheduler-time-zones` endpoint. The server's own zone is flagged in that listing and
+reported in the startup log.
+
 ## Scheduling and Jobs
 
 * Added a **log rate** parameter.


### PR DESCRIPTION
## Change

Adds a **Timezones** section to the v2.0.1 release notes. A schedule can
declare its own zone by prefixing the cron expression:

```
CRON_TZ=America/New_York 0 30 9 * * MON-FRI
TZ="Europe/Berlin" 0 0 3 * * *
```

The expression is evaluated in the declared zone and the resulting fire
time is converted back to the scheduler's own timezone. With no prefix
it is evaluated directly in the scheduler's timezone.

## Verified against the code

- `parser.go:328` `parseTimezone()` in `netresearch/go-cron` v0.14.0
  accepts `TZ=` / `CRON_TZ=` and returns `time.Local` when absent
- `cron/cron_service.go:94` builds the cron with
  `cron.New(cron.WithParser(cron.FullParser()))` — no `WithLocation`, so
  it inherits go-cron's default `location: time.Local` (`cron.go:500`)
- `spec.go:374` / `spec.go:467` — `Next()` computes in the schedule's
  location via `prepareTimeForSchedule` and returns `t.In(origLocation)`
- `cron/cron_service.go:162` `Validate()` parses on schedule creation, so
  an unknown zone is rejected up front

## Framing

The prefix is **not** new — `robfig/cron` v3.0.1 accepted it too
(`parser.go:95`), so the note documents the capability without claiming
it as a new feature. What actually changed in this release:

- matching single/double quotes around the zone name are now stripped
  (`parser.go:341`); robfig passed them through to the zone lookup, so
  `TZ="UTC"` was previously rejected
- the new authenticated `GET /scheduler-time-zones` endpoint lists the
  zones the scheduler recognises, sourced from the timezone file the
  `tzlist` binary generates

## Also applied outside this PR

- GitHub release `v2.0.1` body updated (4701 -> 5679 chars)
- `ci-release-notes/ocf-scheduler-release-notes.md` updated
  (commit `4140eb4`), header and all 65 raw-commit entries preserved