### PR TITLE
Accept v- prefixed release tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,13 @@ define is_not_number
 $(shell echo ${1} | sed -e 's/[0123456789]//g')
 endef
 
-CLEAN_VERSION = $(patsubst v%,%,$(VERSION))
+# Accept both 'vX.Y.Z' (legacy) and 'v-X.Y.Z' (current). Go refuses to
+# resolve a 'vN.Y.Z' tag for N>=2 unless the module path carries a '/vN'
+# suffix; 'v-N.Y.Z' is not valid semver, so Go never version-parses it and
+# it stays usable as a `go get` revision. Strip 'v-' before 'v' — reversed,
+# the 'v' rule leaves a leading '-' that HAS_PRERELEASE below then reads as
+# a prerelease separator, marking a GA release as a prerelease.
+CLEAN_VERSION = $(patsubst v%,%,$(patsubst v-%,%,$(VERSION)))
 HAS_BUILDMETA := $(findstring +,$(CLEAN_VERSION))
 VERSION_BUILDMETA := $(if $(HAS_BUILDMETA),$(lastword $(subst +, ,$(CLEAN_VERSION))),)
 
@@ -36,7 +42,7 @@ VERSION_SPLIT:=$(subst ., ,$(VERSION_ONLY))
   endif
 else
 VERSION_TAG:=$(shell git describe --tags --abbrev=0 2>/dev/null || echo 0.0.0)
-CLEAN_VERSION_TAG = $(patsubst v%,%,$(VERSION_TAG))
+CLEAN_VERSION_TAG = $(patsubst v%,%,$(patsubst v-%,%,$(VERSION_TAG)))
 VERSION_SPLIT:=$(subst ., ,$(CLEAN_VERSION_TAG))
   ifneq ($(words $(VERSION_SPLIT)),3)
     $(error VERSION_TAG does not have 3 parts |$(words $(VERSION_SPLIT))|$(VERSION_TAG)|$(VERSION_SPLIT)|)

--- a/ci/pipeline/jobs/ship-release.yml
+++ b/ci/pipeline/jobs/ship-release.yml
@@ -19,6 +19,7 @@ jobs:
         DEVELOP_BRANCH:   (( grab meta.github.branch ))
         RELEASE_BRANCH:   (( grab meta.github.main-branch ))
         RELEASE_ROOT:     gh
+        TAG_PREFIX:       v-
         RELEASE_NOTES:    (( grab meta.github.release_notes.file ))
         NOTIFICATION_OUT: notifications
         GITHUB_OWNER:     (( grab meta.github.owner ))

--- a/ci/pipeline/resources/git-latest-tag.yml
+++ b/ci/pipeline/resources/git-latest-tag.yml
@@ -7,6 +7,9 @@ resources:
     uri:         (( grab meta.github.uri ))
     branch:      (( grab meta.github.branch ))
     private_key: (( grab meta.github.private_key ))
-    tag_regex:   '^v[0-9\.]*$'
+    # 'v-' scheme only. Legacy bare 'vN.Y.Z' tags are deliberately excluded
+    # so this resource tracks the current naming and cannot regress onto a
+    # pre-2.0.2 tag. See the Makefile CLEAN_VERSION comment for why 'v-'.
+    tag_regex:   '^v-[0-9\.]*$'
     disable_ci_skip: true
 

--- a/ci/scripts/release
+++ b/ci/scripts/release
@@ -26,6 +26,12 @@ bail() {
 export REPO_ROOT="git"
 export RELEASE_NOTES_ROOT="release-notes"
 export VERSION_FROM="version/number"
+# Prefix for the git tag this release cuts. 'v' is the historical default;
+# repos whose major version has outrun their Go module path set 'v-', which
+# Go never version-parses and so will resolve as a `go get` revision.
+# Applies to the tag only -- the release title and the release-notes header
+# marker stay 'v${VERSION}'.
+TAG_PREFIX="${TAG_PREFIX:-v}"
 [[ "${PRERELEASE:-0}" =~ (0|f|false|n|no) ]] && PRERELEASE=""
 
 
@@ -70,8 +76,8 @@ fi
 
 header "Assembling Github Release Artifacts..."
 mkdir -p "${RELEASE_ROOT}/artifacts"
-echo "v${VERSION}"           "-> ${RELEASE_ROOT}/tag"
-echo "v${VERSION}"            > "${RELEASE_ROOT}/tag"
+echo "${TAG_PREFIX}${VERSION}" "-> ${RELEASE_ROOT}/tag"
+echo "${TAG_PREFIX}${VERSION}" > "${RELEASE_ROOT}/tag"
 echo "v${VERSION}"           "-> ${RELEASE_ROOT}/name"
 echo "v${VERSION}"            > "${RELEASE_ROOT}/name"
 if [[ -n "$PRERELEASE" ]] ; then
@@ -119,7 +125,7 @@ if [[ -z "${PRERELEASE}" && "$DEVELOP_BRANCH" != "$RELEASE_BRANCH" ]] ; then
 fi
 
 cat > "${NOTIFICATION_OUT:-notifications}/message" <<EOS
-New ${APP_NAME} v${VERSION} released. <https://github.com/${GITHUB_OWNER}/${APP_NAME}/releases/tag/v${VERSION}|Release notes>.
+New ${APP_NAME} v${VERSION} released. <https://github.com/${GITHUB_OWNER}/${APP_NAME}/releases/tag/${TAG_PREFIX}${VERSION}|Release notes>.
 EOS
 
 echo

--- a/ci/tasks/release.yml
+++ b/ci/tasks/release.yml
@@ -22,6 +22,7 @@ outputs:
 
 params:
   RELEASE_ROOT:     gh
+  TAG_PREFIX:       v
   NOTIFICATION_OUT: notifications
   DEVELOP_BRANCH:   develop
   RELEASE_BRANCH:   main

--- a/ci/tasks/release.yml
+++ b/ci/tasks/release.yml
@@ -22,7 +22,7 @@ outputs:
 
 params:
   RELEASE_ROOT:     gh
-  TAG_PREFIX:       v
+  TAG_PREFIX:       v-
   NOTIFICATION_OUT: notifications
   DEVELOP_BRANCH:   develop
   RELEASE_BRANCH:   main


### PR DESCRIPTION
### Why

Go version-parses a tag named `vN.Y.Z` and, for `N>=2`, refuses to resolve it unless the module path carries a matching `/vN` suffix:

```
$ go list -m github.com/cloudfoundry-community/ocf-scheduler@v2.0.1
go: invalid version: module contains a go.mod file, so module path must
    match major version (".../v2")
```

`+incompatible` doesn't help — it's refused too, because the repo has a `go.mod`. So `v2.0.0` and `v2.0.1` are not resolvable module versions, and `go list -m -versions` stops at `v1.0.3`.

Renaming the module to `/v2` would fix it, but costs 138 import lines across 77 files plus Dockerfiles, Makefile, README and CI config, to buy a cosmetic version string on a repo that is a server binary and a BOSH release rather than a general-purpose library.

A tag named `v-N.Y.Z` is not valid semver, so Go never version-parses it — it's just a ref name, like a branch — and stays usable as a `go get` revision. Same trick `k8s.io/client-go` uses with its `kubernetes-1.29.0` tags.

### What

- `Makefile` — `CLEAN_VERSION` and `CLEAN_VERSION_TAG` accept both `vN.Y.Z` and `v-N.Y.Z`.
- `ci/pipeline/resources/git-latest-tag.yml` — `tag_regex` tracks the `v-` scheme only.
- `ci/scripts/release` — new `TAG_PREFIX` (default `v`) drives the tag file and the Slack release link; `ship-release` sets `v-`.

The read side and the write side have to land together: `tag_regex` now matches only `v-*`, so if `ship-release` still cut a bare tag the resource would match nothing and `prepare` would lose its tag input.

**Strip order is load-bearing.** `v-` must be stripped before `v`. Reversed, the `v` rule eats the prefix and leaves a leading `-`, which `HAS_PRERELEASE` then reads as semver's own prerelease separator:

```
unpatched:  VERSION=v-2.0.1   ->  ONLY=2.0.1  PRE=-2.0.1     # GA marked prerelease
patched:    VERSION=v-2.0.1   ->  ONLY=2.0.1  PRE=
```

Neither the 3-part guard nor the numeric-patch guard catches the bad value, so this would have failed silently into the binary.

### Verification

`make debug_version` against both branches of the `ifneq`, six input forms:

| input | `VERSION_ONLY` | prerelease | buildmeta |
|---|---|---|---|
| `v2.0.1` | 2.0.1 | — | — |
| `v-2.0.1` | 2.0.1 | — | — |
| `v2.0.1-rc.1` | 2.0.1 | rc.1 | — |
| `v-2.0.1-rc.1` | 2.0.1 | rc.1 | — |
| `v-2.0.1+deadbeef` | 2.0.1 | — | deadbeef |
| `2.0.1` | 2.0.1 | — | — |

Backward compatible: bare `vN.Y.Z`, bare `N.Y.Z` and existing `-rc.N` prereleases all keep working, so nothing needs migrating in lockstep.

`ci/scripts/release` run against a fixture at `VERSION=2.0.2`:

| `TAG_PREFIX` | tag | release title |
|---|---|---|
| unset | `v2.0.2` | `v2.0.2` |
| `v` | `v2.0.2` | `v2.0.2` |
| `v-` | `v-2.0.2` | `v2.0.2` |

`ship-prerelease` shares this script through a separate task file and keeps the `v` default, so prerelease tags are unchanged.

### Not in this PR

- Backfilling `v-2.0.1` onto `a3fd09e`.
- `scripts/genver` breaks on `v-`, but has zero callers; proposed for deletion separately.
