### PR TITLE
Move prereleases to the v- tag scheme

### DIFF
--- a/ci/pipeline/jobs/ship-prerelease.yml
+++ b/ci/pipeline/jobs/ship-prerelease.yml
@@ -21,6 +21,7 @@ jobs:
         DEVELOP_BRANCH:   (( grab meta.github.branch ))
         RELEASE_BRANCH:   (( grab meta.github.branch ))
         RELEASE_ROOT:     gh
+        TAG_PREFIX:       v-
         RELEASE_NOTES:    (( grab meta.github.release_notes.file ))
         NOTIFICATION_OUT: notifications
         GITHUB_OWNER:     (( grab meta.github.owner ))

--- a/ci/scripts/release
+++ b/ci/scripts/release
@@ -26,12 +26,15 @@ bail() {
 export REPO_ROOT="git"
 export RELEASE_NOTES_ROOT="release-notes"
 export VERSION_FROM="version/number"
-# Prefix for the git tag this release cuts. 'v' is the historical default;
-# repos whose major version has outrun their Go module path set 'v-', which
-# Go never version-parses and so will resolve as a `go get` revision.
+# Prefix for the git tag this release cuts. 'v-' is this repo's scheme: Go
+# never version-parses a non-semver tag name, so a v- tag resolves as a
+# `go get` revision even though the major version has outrun the module
+# path. Every caller sets it explicitly; this default only matters if a
+# future task forgets to, and landing on the repo's actual convention is a
+# safer miss than silently reverting to the legacy 'v'.
 # Applies to the tag only -- the release title and the release-notes header
 # marker stay 'v${VERSION}'.
-TAG_PREFIX="${TAG_PREFIX:-v}"
+TAG_PREFIX="${TAG_PREFIX:-v-}"
 [[ "${PRERELEASE:-0}" =~ (0|f|false|n|no) ]] && PRERELEASE=""
 
 

--- a/ci/tasks/prerelease.yml
+++ b/ci/tasks/prerelease.yml
@@ -23,6 +23,7 @@ outputs:
 params:
   PRERELEASE:       1
   RELEASE_ROOT:     gh
+  TAG_PREFIX:       v-
   NOTIFICATION_OUT: notifications
   DEVELOP_BRANCH:   develop
   RELEASE_BRANCH:   main


### PR DESCRIPTION
### Why

PR #25 moved releases to the `v-` tag scheme but deliberately left `ship-prerelease` on the old `v` default, so the repo has been running two tag conventions with no reason for the split. This finishes the migration.

Background, for anyone arriving cold: Go version-parses a tag named `vN.Y.Z` and, for `N>=2`, refuses to resolve it unless the module path carries a matching `/vN` suffix. A tag named `v-N.Y.Z` is not valid semver, so Go never version-parses it — it stays usable as a `go get` revision without renaming the module.

**This one has no functional gain on its own.** An rc tag is not module-resolvable in either form, because the prerelease suffix isn't numeric. The value is consistency: one convention now covers every tag the pipeline produces.

### What

- `ci/tasks/prerelease.yml` — `TAG_PREFIX: v-`
- `ci/pipeline/jobs/ship-prerelease.yml` — `TAG_PREFIX: v-`
- `ci/scripts/release` — default changed from `v` to `v-`

All four callers of `ci/scripts/release` now set `TAG_PREFIX` explicitly, so the script default fires only if a future task omits it. Landing on the repo's actual scheme is a safer miss than silently reverting to the legacy `v`, which would cut a tag Go refuses to resolve. An explicit `TAG_PREFIX=v` still works, so a vendored copy can opt back in.

### Verification

`ci/scripts/release` run against a fixture on the `PRERELEASE=1` path:

| `TAG_PREFIX` | tag | release title |
|---|---|---|
| unset (old default `v`) | `v2.0.2-rc.1` | `v2.0.2-rc.1` |
| `v-` | `v-2.0.2-rc.1` | `v2.0.2-rc.1` |
| unset (new default `v-`) | `v-2.0.2-rc.1` | `v2.0.2-rc.1` |
| explicit `v` | `v2.0.2-rc.1` | `v2.0.2-rc.1` |

The release title and the release-notes header marker stay `v${VERSION}` — same split as releases, since that string is a notes-file convention rather than a git ref.

### After merge

Needs `ci/repipe -y`, since `ci/pipeline/jobs/ship-prerelease.yml` changed. Unlike #25 this batch is `ci/`-only, and the `git` resource has `ignore_paths: ["ci"]`, so it does **not** need to clear build → test → prepare first.

### Not in this PR

The existing `v2.0.1-rc.1` tag stays as-is. It's harmless, it's bound to a published prerelease, and deleting tags is what strands the Concourse `git-latest-tag` resource. No `v-` alias is needed for a prerelease, since nothing resolves rc tags as module versions.
